### PR TITLE
Use SPDX identifier in license field of META.info

### DIFF
--- a/META.info
+++ b/META.info
@@ -1,6 +1,7 @@
 {
         "perl" : "6.*",
         "name" : "Acme::Flutterby",
+        "license" : "Artistic-2.0",
         "version" : "0.01",
         "description" : "Acme::Flutterby - An object-oriented interface to a butterfly.  In what else but Perl 6...",
         "author" : "John Scoles",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license